### PR TITLE
Prevent an error when the pick command can be missing some arguments

### DIFF
--- a/random/module.py
+++ b/random/module.py
@@ -35,6 +35,11 @@ class Random(commands.Cog):
                 args = args[i + 1:]
                 break
 
+        if len(args) < 2:
+            return await ctx.reply(
+                _(ctx, "You asked a question, but did not add enough options.")
+            )
+
         option: Optional[str] = utils.Text.sanitise(random.choice(args))
         if option is not None:
             await ctx.reply(option)


### PR DESCRIPTION
Addressing the issue mentioned here : https://github.com/pumpkin-py/pumpkin-fun/pull/11#issuecomment-933604020