### PR TITLE
DHash: Scan URLs for duplications

### DIFF
--- a/po/cs.popie
+++ b/po/cs.popie
@@ -1,3 +1,18 @@
+msgid Regex for allowed URLs is `{regex}`.
+msgstr Regex pro povolené URL je `{regex}`.
+
+msgid Regex for allowed URLs is not set.
+msgstr Regex pro povolené URL není nastaven.
+
+msgid Regex for allowed urls successfuly unset.
+msgstr Regex pro povolené adresy úspěšně zrušen.
+
+msgid String `{regex}` is not valid regex.
+msgstr Řetězec `{regex}` není validní regex.
+
+msgid String `{regex}` was successfuly set as allowed urls.
+msgstr Řetězec pro povolené URL adresy byl nastaven na `{regex}`.
+
 msgid {channel} is already hash channel.
 msgstr {channel} je již nastaven jako hash kanál.
 

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -1,3 +1,18 @@
+msgid Regex for allowed URLs is `{regex}`.
+msgstr Regex pre povolené URL je `{regex}`.
+
+msgid Regex for allowed URLs is not set.
+msgstr Regex pre povolené URL nie je nastavený.
+
+msgid Regex for allowed urls successfuly unset.
+msgstr Regex pre povolené adresy úspešne zrušený.
+
+msgid String `{regex}` is not valid regex.
+msgstr Reťazec `{regex}` nie je validný regex.
+
+msgid String `{regex}` was successfuly set as allowed urls.
+msgstr Reťazec pre povolené URL adresy bol nastavený na `{regex}`.
+
 msgid {channel} is already hash channel.
 msgstr Kanál {channel} je už nastavený ako hash kanál.
 


### PR DESCRIPTION
If user was sending image into dhash channel as URL, not attachement, bot was not computing dhash and checking for repost. Now it does so.

First it opens URL and checks header for content size and content type. If it's bigger than limit or it's not image, the URL is skipped.

Then it fetches image using read() and passes it into ImageFile.Parser(). If fetched data is somehow bigger than limit (failsafe), downloading is stopped.

After that the parser is closed and that produces Image object or throws OSError (which is ignored).

If everything works well, it computes dhash for that image and that dhash is inserted into database. Because there's no attachment, property attachment_id is set to 0.

For this reason I've also added note into ImageHash.get_by_attachement(...) function (unused ATM) and also changed datetime parsing in repost embed from attachement_id to message_id.

Because I'm using urllib, I've added requests as dependency for sure (it's also dependency for nextcord.py, so maybe it's unnecessary)

The only problem I've encountered was caused by Cloudflare not allowing urllib agent fetch images which caused 403 - Forbidden error. It's bypassed by using own agent information in header.

Because there were some concerns about using this feature for exposing bot's IP address, I've added option to set regex for URL check.