### PR TITLE
DHash: Ensure URL file size limit check

### DIFF
--- a/dhash/module.py
+++ b/dhash/module.py
@@ -479,7 +479,7 @@ class Dhash(commands.Cog):
                     auto_decompress=False,
                     read_bufsize=256,
                 ) as session:
-                    async with session.get(url) as resp:
+                    async with session.get(url, read_until_eof=False) as resp:
                         if resp.status != 200:
                             continue
                         size = resp.headers.get("content-length")


### PR DESCRIPTION
On one hand aiohttp client uses `read_until_eof` argument to ensure that downloaded file is not bigger than content-length. On the other if it's not explicitly set, it's some kind of magic value. This fix makes sure that it's not just checking EOF when reading images from internet, but it completly relies on content-length.