### PR TITLE
Weather: Limit lenght of place in forecast to 32 characters only

### DIFF
--- a/weather/module.py
+++ b/weather/module.py
@@ -166,7 +166,8 @@ class Weather(commands.Cog):
                 author=ctx.message.author,
                 title=title,
                 description=_(ctx, "Weather forecast for **{place}**, {date}").format(
-                    date=day["date"], place=name
+                    date=day["date"],
+                    place=name[0:32] + ("..." if len(name) > 32 else ""),
                 ),
             )
 


### PR DESCRIPTION
Resolves #74