### PR TITLE
Port shop

### DIFF
--- a/names/database.py
+++ b/names/database.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import Column, Integer, BigInteger
+
+from pie.database import database, session
+
+
+class Price(database.base):
+    """Prices for nickname subcommands"""
+
+    __tablename__ = "fun_names_prices"
+
+    guild_id = Column(BigInteger, primary_key=True)
+    set_price = Column(Integer)
+    reset_price = Column(Integer)
+
+    @staticmethod
+    def set(guild_id: int, set_price: int, reset_price: int) -> Price:
+        """Add or update prices."""
+        price = Price.get(guild_id)
+        if price is not None:
+            price.set_price = set_price
+            price.reset_price = reset_price
+        else:
+            price = Price(
+                guild_id=guild_id,
+                set_price=set_price,
+                reset_price=reset_price,
+            )
+        session.add(price)
+        session.commit()
+        return price
+
+    @staticmethod
+    def get(guild_id: int) -> Optional[Price]:
+        """Get prices in supplied guild."""
+        return session.query(Price).filter_by(guild_id=guild_id).one_or_none()
+
+    @staticmethod
+    def remove(guild_id: int) -> int:
+        """Remove prices in supplied guild."""
+        price = session.query(Price).filter_by(guild_id=guild_id).delete()
+        session.commit()
+        return price

--- a/names/module.py
+++ b/names/module.py
@@ -1,0 +1,200 @@
+import discord
+from discord.ext import commands
+
+from pie import check, utils, i18n, logger
+from modules.base.admin.database import BaseAdminModule
+from modules.boards.karma.database import KarmaMember
+
+from .database import Price
+
+_ = i18n.Translator("modules/fun").translate
+bot_log = logger.Bot.logger()
+
+
+class Names(commands.Cog):
+    """Pay by karma and I change your name."""
+
+    def __init__(self, bot: commands.Bot):
+        # Check if dependency module is loaded.
+        if not BaseAdminModule.get("boards.karma").enabled:
+            raise Exception(
+                "Unable to load names module due to missing module `boards.karma`."
+            )
+
+        self.bot = bot
+
+    @commands.bot_has_permissions(manage_nicknames=True)
+    @commands.guild_only()
+    @check.acl2(check.ACLevel.EVERYONE)
+    @commands.cooldown(rate=5, per=20.0, type=commands.BucketType.user)
+    @commands.group(name="nickname", aliases=["name"])
+    async def nickname_(self, ctx):
+        """Change your nickname"""
+        await utils.discord.send_help(ctx)
+
+    @commands.guild_only()
+    @check.acl2(check.ACLevel.EVERYONE)
+    @commands.cooldown(rate=5, per=20.0, type=commands.BucketType.user)
+    @nickname_.command(name="prices")
+    async def prices(self, ctx):
+        """Display prices for various name/nickname operations"""
+
+        embed = utils.discord.create_embed(
+            author=ctx.author,
+            title=_(ctx, "Change of nickname"),
+            description=_(
+                ctx,
+                "Values are in karma points. Use commnand **nickname/name** for more info.",
+            ),
+        )
+        price = Price.get(ctx.guild.id)
+        embed.add_field(
+            name=_(ctx, "Set"),
+            value=_(ctx, "Price **{price}**").format(
+                price=price.set_price if price is not None else _(ctx, "not set")
+            ),
+        )
+        embed.add_field(
+            name=_(ctx, "Reset"),
+            value=_(ctx, "Price **{price}**").format(
+                price=price.reset_price if price is not None else _(ctx, "not set")
+            ),
+        )
+
+        await ctx.reply(embed=embed)
+
+    @commands.guild_only()
+    @check.acl2(check.ACLevel.EVERYONE)
+    @commands.cooldown(rate=5, per=20.0, type=commands.BucketType.user)
+    @nickname_.command(name="set")
+    async def nickname_set(self, ctx, nickname: str):
+        """Change server nickname"""
+        if not BaseAdminModule.get("boards.karma").enabled:
+            await bot_log.error(
+                ctx.author,
+                ctx.channel,
+                "Repository boards.karma is not loaded. Cannot set nickname.",
+            )
+            await ctx.reply(
+                _(ctx, "Cannot change nickname because module karma is not loaded.")
+            )
+            return
+
+        if nickname == ctx.author.display_name:
+            await ctx.reply(
+                _(
+                    ctx,
+                    "New nickname {nickname} is same as current nickname. No need to change.",
+                ).format(nickname=nickname)
+            )
+            return
+
+        price = Price.get(ctx.guild.id)
+        if price is None:
+            await ctx.reply(
+                _(ctx, "Unable to change nickname, this command has no set price.")
+            )
+            return
+
+        member = KarmaMember.get_or_add(ctx.author.guild.id, ctx.author.id)
+        if member.value < price.set_price:
+            await ctx.reply(_(ctx, "No enough karma, try to chat more to earn karma."))
+            return
+
+        for char in ("@", "#", "`", "'", '"'):
+            if char in nickname:
+                await ctx.reply(
+                    _(ctx, "{nickname} includes some forbidden characters.").format(
+                        nickname=nickname
+                    )
+                )
+                return
+
+        try:
+            await ctx.author.edit(nick=nickname, reason="Nickname purchase")
+        except discord.Forbidden:
+            await ctx.reply(
+                _(ctx, "Cannot change nickname because you have greater privileges.")
+            )
+            return
+
+        member.value += -price.set_price
+        member.save()
+
+        await ctx.reply(
+            _(
+                ctx, "Congratulation! You were successfully renamed to {nickname}."
+            ).format(nickname=nickname)
+        )
+
+    @commands.guild_only()
+    @check.acl2(check.ACLevel.EVERYONE)
+    @commands.cooldown(rate=5, per=20.0, type=commands.BucketType.user)
+    @nickname_.command(name="unset", aliases=["reset"])
+    async def nickname_unset(self, ctx):
+        """Change your nickname back to global from server"""
+        if not BaseAdminModule.get("boards.karma").enabled:
+            await bot_log.error(
+                ctx.author,
+                ctx.channel,
+                "Repository boards.karma is not loaded. Cannot reset nickname.",
+            )
+            await ctx.reply(
+                _(ctx, "Cannot change nickname because mudule karma is not loaded.")
+            )
+            return
+
+        price = Price.get(ctx.guild.id)
+        if price is None:
+            await ctx.reply(
+                _(ctx, "Unable to reset nickname, this command has no set price.")
+            )
+            return
+
+        member = KarmaMember.get_or_add(ctx.author.guild.id, ctx.author.id)
+        if member.value < price.reset_price:
+            await ctx.reply(_(ctx, "No enough karma, try to chat more to earn karma."))
+            return
+
+        if ctx.author.nick is None:
+            await ctx.reply(_(ctx, "You are already using username."))
+            return
+
+        try:
+            await ctx.author.edit(nick=None, reason="Nickname reset")
+        except discord.Forbidden:
+            await ctx.reply(
+                _(ctx, "Cannot change nickname because you have greater privileges.")
+            )
+            return
+
+        member.value += -price.reset_price
+        member.save()
+
+        await ctx.reply(
+            _(ctx, "Congratulation! You are now using username not nickname.")
+        )
+
+    @commands.guild_only()
+    @check.acl2(check.ACLevel.MOD)
+    @commands.cooldown(rate=5, per=20.0, type=commands.BucketType.user)
+    @nickname_.command(name="set-prices", aliases=["set_prices"])
+    async def nickname_set_prices(self, ctx, set_price: int, reset_price: int):
+        """Change prices for set and reset"""
+        if set_price < 0 or reset_price < 0:
+            await ctx.reply(
+                _(
+                    ctx,
+                    "Unable to change the price because one of the prices have negative value.",
+                )
+            )
+            return
+        price = Price.set(ctx.guild.id, set_price, reset_price)
+        if price is not None:
+            await ctx.reply(_(ctx, "Prices have been successfully updated."))
+        else:
+            await ctx.reply(_(ctx, "Prices have not been successfully updated."))
+
+
+async def setup(bot) -> None:
+    await bot.add_cog(Names(bot))

--- a/po/cs.popie
+++ b/po/cs.popie
@@ -214,6 +214,63 @@ msgstr Makro **{name}** aktualizováno.
 msgid Macro **{name}** removed.
 msgstr Makro **{name}** odebráno.
 
+msgid Change of nickname
+msgstr Změna přezdívky
+
+msgid Values are in karma points. Use commnand **nickname/name** for more info.
+msgstr Hodnoty jsou udávané v karma bodech. Použití příkazu **nickname/name** pro více informací.
+
+msgid Set
+msgstr Set
+
+msgid Price **{price}**
+msgstr Cena **{price}**
+
+msgid Reset
+msgstr Reset
+
+msgid Cannot change nickname because module karma is not loaded.
+msgstr Nelze změnit přezdívku, protože modul karma není načten.
+
+msgid New nickname {nickname} is same as current nickname. No need to change.
+msgstr Nová přezdívka {nickname} je stejná jako aktuální, takže ji není třeba měnit.
+
+msgid Unable to change nickname, this command has no set price.
+msgstr Není možné změnit přezdívku, jelikož příkaz nemá nastavenou cenu.
+
+msgid No enough karma, try to chat more to earn karma.
+msgstr Nedostatek karmy, pro zisk karmy se více zapoj do konverzace.
+
+msgid {nickname} includes some forbidden characters.
+msgstr {nickname} obsahuje některý z nepovolených znaků.
+
+msgid Cannot change nickname because you have greater privileges.
+msgstr Není možné změnit přezdívku z důvodu vyššího oprávnění.
+
+msgid Congratulation! You were successfully renamed to {nickname}.
+msgstr Gratulace! Byl jsi uspěšně přejměnován na {nickname}.
+
+msgid Cannot change nickname because mudule karma is not loaded.
+msgstr Není možné změnit jméno, protože modul karma není načten.
+
+msgid Unable to reset nickname, this command has no set price.
+msgstr Není možné resetovat přezdívku, jelikož příkaz nemá nastavenou cenu.
+
+msgid You are already using username.
+msgstr Aktuálně už používáš uživatelské jméno.
+
+msgid Congratulation! You are now using username not nickname.
+msgstr Gratulace! Právě používáš uživatelské jméno a ne přezdívku.
+
+msgid Unable to change the price because one of the prices have negative value.
+msgstr Nění možné změnit cenu, jelikož jedna z cen je záporná.
+
+msgid Prices have been successfully updated.
+msgstr Ceny byly uspěšně aktualizovány.
+
+msgid Prices have not been successfully updated.
+msgstr Ceny nebyly úspěšně aktualizovány.
+
 msgid You asked a question, but did not add enough options.
 msgstr Ptáš se na otázku, ale nemám dost možností k výběru.
 

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -214,6 +214,63 @@ msgstr Makro **{name}** aktualizované.
 msgid Macro **{name}** removed.
 msgstr Makro **{name}** vymazané.
 
+msgid Change of nickname
+msgstr
+
+msgid Values are in karma points. Use commnand **nickname/name** for more info.
+msgstr
+
+msgid Set
+msgstr
+
+msgid Price **{price}**
+msgstr
+
+msgid Reset
+msgstr
+
+msgid Cannot change nickname because module karma is not loaded.
+msgstr
+
+msgid New nickname {nickname} is same as current nickname. No need to change.
+msgstr
+
+msgid Unable to change nickname, this command has no set price.
+msgstr
+
+msgid No enough karma, try to chat more to earn karma.
+msgstr
+
+msgid {nickname} includes some forbidden characters.
+msgstr
+
+msgid Cannot change nickname because you have greater privileges.
+msgstr
+
+msgid Congratulation! You were successfully renamed to {nickname}.
+msgstr
+
+msgid Cannot change nickname because mudule karma is not loaded.
+msgstr
+
+msgid Unable to reset nickname, this command has no set price.
+msgstr
+
+msgid You are already using username.
+msgstr
+
+msgid Congratulation! You are now using username not nickname.
+msgstr
+
+msgid Unable to change the price because one of the prices have negative value.
+msgstr
+
+msgid Prices have been successfully updated.
+msgstr
+
+msgid Prices have not been successfully updated.
+msgstr
+
 msgid You asked a question, but did not add enough options.
 msgstr Opýtal si sa otázku, ale nemám na výber dostatok možností.
 

--- a/repo.conf
+++ b/repo.conf
@@ -3,6 +3,7 @@ name = fun
 modules =
 	dhash
 	fun
+	names
 	macro
 	rand
 	seeking


### PR DESCRIPTION
Hi, this PR should resolve #3 .

I take most of the logic from shop and add some checks. When loading module, there is a check if karma module is loaded + every time the `set` or `reset` is used it also check if karma module is loaded.  

Feature:
- Now you can dynamically change the price of name services.  

- [x] Tested locally on own server with two user
- [X] Run black
- [X] Run flake8 
- [X] Run popie and add cz strings