### PR TITLE
Rand: fix picsum footer.

### DIFF
--- a/rand/module.py
+++ b/rand/module.py
@@ -83,7 +83,7 @@ class Rand(commands.Cog):
 
         footer: str = "picsum.photos"
         if seed:
-            footer += f" ({seed})"
+            footer += f" ({seed})" if len(seed) <= 16 else f" ({seed[:16]}…)"
 
         embed: discord.Embed = utils.discord.create_embed(
             author=ctx.author,


### PR DESCRIPTION
Picsum footer will no longer break upon long seeds.
Resolves #69 