### PR TITLE
Rewrite Weather to use yr.no data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           popie --detached --strict --diff .
 
+      - name: Run pytest
+        run: |
+          PYTHONPATH=. pytest _test/ -vl
+
       - name: Check TODOs
         run: |
           flake8 . --select=T --exit-zero

--- a/_test/test_weather.py
+++ b/_test/test_weather.py
@@ -1,0 +1,132 @@
+import datetime
+import json
+from pathlib import Path
+
+try:
+    # Pure pytest, with `PYTHONPATH=.` as env var
+    from weather import process
+except ImportError:
+    # IDE, like PyCharm
+    from modules.fun.weather import process
+
+TIMEZONE = datetime.timezone(datetime.timedelta(hours=1))
+"""Timezone used for most examples"""
+
+
+class Test:
+    def request(self, filename: str) -> dict:
+        this = Path(__file__)
+        with open(this.parent / filename, "r") as handle:
+            return json.load(handle)
+
+    def test_split_into_days(self):
+        data = self.request("weather-0.json")
+        points = data["properties"]["timeseries"]
+
+        result = process.split_into_days(points, timezone=TIMEZONE)
+        assert "2022-11-04" in result.keys()
+        assert "2022-11-14" in result.keys()
+        assert "2022-11-15" not in result.keys()
+
+        assert type(result["2022-11-04"]) is dict
+        assert type(result["2022-11-14"]) is dict
+
+        assert "20:00:00" in result["2022-11-04"]
+        assert "23:00:00" in result["2022-11-04"]
+        assert "01:00:00" in result["2022-11-14"]
+
+    def test_split_into_days_specific(self):
+        data = self.request("weather-0.json")
+        points = data["properties"]["timeseries"]
+
+        result = process.split_into_days(points, timezone=TIMEZONE)
+
+        expected = {
+            "instant": {
+                "details": {
+                    "air_pressure_at_sea_level": 1015.4,
+                    "air_temperature": 16.1,
+                    "cloud_area_fraction": 0.0,
+                    "cloud_area_fraction_high": 0.0,
+                    "cloud_area_fraction_low": 0.0,
+                    "cloud_area_fraction_medium": 0.0,
+                    "dew_point_temperature": 15.3,
+                    "fog_area_fraction": 0.0,
+                    "relative_humidity": 94.4,
+                    "ultraviolet_index_clear_sky": 0.0,
+                    "wind_from_direction": 142.0,
+                    "wind_speed": 2.6,
+                },
+            },
+            "next_12_hours": {"summary": {"symbol_code": "clearsky_day"}},
+            "next_1_hours": {
+                "details": {"precipitation_amount": 0.0},
+                "summary": {"symbol_code": "clearsky_night"},
+            },
+            "next_6_hours": {
+                "details": {
+                    "air_temperature_max": 24.5,
+                    "air_temperature_min": 15.6,
+                    "precipitation_amount": 0.0,
+                },
+                "summary": {"symbol_code": "clearsky_day"},
+            },
+        }
+        assert expected == result["2022-11-05"]["02:00:00"]
+
+    def test_filter_point(self):
+        data = self.request("weather-0.json")
+        point = data["properties"]["timeseries"][0]["data"]
+
+        result = process.filter_point(point)
+        expected = {
+            "air_pressure": 1015.2,
+            "air_temperature": 21.7,
+            "cloudiness": 0.0,
+            "fogginess": 0.0,
+            "relative_humidity": 47.2,
+            "uv_index": 0.0,
+            "wind_speed": 2.8,
+        }
+        assert expected == result
+
+    def test_join_points(self):
+        points = self.request("weather-0-filtered.json")
+
+        joined = process.join_points(points)
+        print(joined)
+
+        assert {0, 6, 12, 18} == joined.keys()
+
+        assert joined[0]["air_pressure"] == (1015.0, 1018.0)
+        assert joined[6]["cloudiness"] == (0.0, 0.8)
+        assert joined[12]["relative_humidity"] == (19.1, 31.0)
+        assert joined[18]["air_temperature"] == (18.1, 22.9)
+
+    def test_contains_meta(self):
+        data = self.request("weather-0.json")
+
+        result = process.filter_forecast_data(data, timezone=TIMEZONE)
+
+        assert "meta" in result
+        assert "units" in result["meta"]
+        assert "updated_at" in result["meta"]
+
+    def test_contains_filtered_day(self):
+        data = self.request("weather-0.json")
+
+        result = process.filter_forecast_data(data, timezone=TIMEZONE)
+        assert result["data"]["2022-11-05"][0]["air_temperature"] == (15.6, 17.4)
+        assert result["data"]["2022-11-07"][0]["fogginess"] == (0.0, 100.0)
+        assert result["data"]["2022-11-07"][6]["fogginess"] == (0.0, 0.0)
+
+    def test_get_daily_minmax(self):
+        data = self.request("weather-0-joined.json")["data"]
+
+        result_05 = process.get_day_minmax(data["2022-11-05"])
+        assert (15.6, 29.6) == result_05["air_temperature"]
+        assert (0.0, 10.9) == result_05["cloudiness"]
+        assert (0.0, 9.6) == result_05["uv_index"]
+
+        result_06 = process.get_day_minmax(data["2022-11-06"])
+        assert (1013.0, 1018.8) == result_06["air_pressure"]

--- a/_test/weather-0-filtered.json
+++ b/_test/weather-0-filtered.json
@@ -1,0 +1,218 @@
+{
+    "00:00:00": {
+        "air_pressure": 1015.0,
+        "air_temperature": 16.7,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 91.8,
+        "uv_index": 0.0,
+        "wind_speed": 2.8
+    },
+    "01:00:00": {
+        "air_pressure": 1015.4,
+        "air_temperature": 16.1,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 94.4,
+        "uv_index": 0.0,
+        "wind_speed": 2.6
+    },
+    "02:00:00": {
+        "air_pressure": 1016.0,
+        "air_temperature": 15.7,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 96.2,
+        "uv_index": 0.0,
+        "wind_speed": 2.8
+    },
+    "03:00:00": {
+        "air_pressure": 1016.7,
+        "air_temperature": 15.6,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 97.6,
+        "uv_index": 0.1,
+        "wind_speed": 3.0
+    },
+    "04:00:00": {
+        "air_pressure": 1017.6,
+        "air_temperature": 17.3,
+        "cloudiness": 10.9,
+        "fogginess": 0.8,
+        "relative_humidity": 94.7,
+        "uv_index": 0.9,
+        "wind_speed": 3.1
+    },
+    "05:00:00": {
+        "air_pressure": 1018.0,
+        "air_temperature": 19.6,
+        "cloudiness": 5.5,
+        "fogginess": 0.0,
+        "relative_humidity": 84.0,
+        "uv_index": 2.9,
+        "wind_speed": 2.9
+    },
+    "06:00:00": {
+        "air_pressure": 1018.2,
+        "air_temperature": 22.2,
+        "cloudiness": 0.8,
+        "fogginess": 0.0,
+        "relative_humidity": 65.8,
+        "uv_index": 5.7,
+        "wind_speed": 3.2
+    },
+    "07:00:00": {
+        "air_pressure": 1017.6,
+        "air_temperature": 24.5,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 51.5,
+        "uv_index": 8.3,
+        "wind_speed": 3.1
+    },
+    "08:00:00": {
+        "air_pressure": 1016.4,
+        "air_temperature": 26.1,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 41.3,
+        "uv_index": 9.6,
+        "wind_speed": 2.7
+    },
+    "09:00:00": {
+        "air_pressure": 1015.2,
+        "air_temperature": 27.3,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 35.0,
+        "uv_index": 9.2,
+        "wind_speed": 2.3
+    },
+    "10:00:00": {
+        "air_pressure": 1014.0,
+        "air_temperature": 28.6,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 27.7,
+        "uv_index": 7.2,
+        "wind_speed": 2.5
+    },
+    "11:00:00": {
+        "air_pressure": 1013.1,
+        "air_temperature": 29.6,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 20.8,
+        "uv_index": 4.4,
+        "wind_speed": 3.3
+    },
+    "12:00:00": {
+        "air_pressure": 1012.8,
+        "air_temperature": 29.6,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 19.2,
+        "uv_index": 1.9,
+        "wind_speed": 4.2
+    },
+    "13:00:00": {
+        "air_pressure": 1013.2,
+        "air_temperature": 29.1,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 19.1,
+        "uv_index": 0.5,
+        "wind_speed": 4.7
+    },
+    "14:00:00": {
+        "air_pressure": 1013.6,
+        "air_temperature": 27.8,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 21.1,
+        "uv_index": 0.0,
+        "wind_speed": 4.5
+    },
+    "15:00:00": {
+        "air_pressure": 1014.2,
+        "air_temperature": 26.6,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 24.2,
+        "uv_index": 0.0,
+        "wind_speed": 4.1
+    },
+    "16:00:00": {
+        "air_pressure": 1015.0,
+        "air_temperature": 25.4,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 27.8,
+        "uv_index": 0.0,
+        "wind_speed": 3.7
+    },
+    "17:00:00": {
+        "air_pressure": 1016.0,
+        "air_temperature": 24.0,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 31.0,
+        "uv_index": 0.0,
+        "wind_speed": 2.8
+    },
+    "18:00:00": {
+        "air_pressure": 1016.7,
+        "air_temperature": 22.9,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 35.5,
+        "uv_index": 0.0,
+        "wind_speed": 3.0
+    },
+    "19:00:00": {
+        "air_pressure": 1016.8,
+        "air_temperature": 22.0,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 44.4,
+        "uv_index": 0.0,
+        "wind_speed": 3.0
+    },
+    "20:00:00": {
+        "air_pressure": 1016.9,
+        "air_temperature": 21.3,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 50.0,
+        "uv_index": 0.0,
+        "wind_speed": 3.6
+    },
+    "21:00:00": {
+        "air_pressure": 1017.3,
+        "air_temperature": 20.1,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 51.5,
+        "uv_index": 0.0,
+        "wind_speed": 3.6
+    },
+    "22:00:00": {
+        "air_pressure": 1017.1,
+        "air_temperature": 19.1,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 63.0,
+        "uv_index": 0.0,
+        "wind_speed": 3.7
+    },
+    "23:00:00": {
+        "air_pressure": 1016.8,
+        "air_temperature": 18.1,
+        "cloudiness": 0.0,
+        "fogginess": 0.0,
+        "relative_humidity": 76.4,
+        "uv_index": 0.0,
+        "wind_speed": 3.8
+    }
+}

--- a/_test/weather-0-joined.json
+++ b/_test/weather-0-joined.json
@@ -1,0 +1,1186 @@
+{
+    "meta": {
+        "updated_at": "2022-11-04T19:26:30Z",
+        "units": {
+            "air_pressure_at_sea_level": "hPa",
+            "air_temperature": "celsius",
+            "air_temperature_max": "celsius",
+            "air_temperature_min": "celsius",
+            "cloud_area_fraction": "%",
+            "cloud_area_fraction_high": "%",
+            "cloud_area_fraction_low": "%",
+            "cloud_area_fraction_medium": "%",
+            "dew_point_temperature": "celsius",
+            "fog_area_fraction": "%",
+            "precipitation_amount": "mm",
+            "relative_humidity": "%",
+            "ultraviolet_index_clear_sky": "1",
+            "wind_from_direction": "degrees",
+            "wind_speed": "m/s"
+        }
+    },
+    "data": {
+        "2022-11-04": {
+            "18": {
+                "air_pressure": [
+                    1015.2,
+                    1015.5
+                ],
+                "air_temperature": [
+                    18.4,
+                    21.7
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    47.2,
+                    78.1
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    2.8,
+                    3.7
+                ]
+            }
+        },
+        "2022-11-05": {
+            "0": {
+                "air_pressure": [
+                    1015.0,
+                    1017.6
+                ],
+                "air_temperature": [
+                    15.6,
+                    17.4
+                ],
+                "cloudiness": [
+                    0.0,
+                    10.9
+                ],
+                "fogginess": [
+                    0.0,
+                    0.8
+                ],
+                "relative_humidity": [
+                    88.0,
+                    97.6
+                ],
+                "uv_index": [
+                    0.0,
+                    0.9
+                ],
+                "wind_speed": [
+                    2.6,
+                    3.1
+                ]
+            },
+            "6": {
+                "air_pressure": [
+                    1014.0,
+                    1018.2
+                ],
+                "air_temperature": [
+                    19.6,
+                    28.6
+                ],
+                "cloudiness": [
+                    0.0,
+                    5.5
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    27.7,
+                    84.0
+                ],
+                "uv_index": [
+                    2.9,
+                    9.6
+                ],
+                "wind_speed": [
+                    2.3,
+                    3.2
+                ]
+            },
+            "12": {
+                "air_pressure": [
+                    1012.8,
+                    1015.0
+                ],
+                "air_temperature": [
+                    25.4,
+                    29.6
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    19.1,
+                    27.8
+                ],
+                "uv_index": [
+                    0.0,
+                    4.4
+                ],
+                "wind_speed": [
+                    3.3,
+                    4.7
+                ]
+            },
+            "18": {
+                "air_pressure": [
+                    1016.0,
+                    1017.3
+                ],
+                "air_temperature": [
+                    19.1,
+                    24.0
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    31.0,
+                    63.0
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    2.8,
+                    3.7
+                ]
+            }
+        },
+        "2022-11-06": {
+            "0": {
+                "air_pressure": [
+                    1016.7,
+                    1018.4
+                ],
+                "air_temperature": [
+                    16.2,
+                    18.1
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    76.4,
+                    94.3
+                ],
+                "uv_index": [
+                    0.0,
+                    0.9
+                ],
+                "wind_speed": [
+                    2.9,
+                    3.8
+                ]
+            },
+            "6": {
+                "air_pressure": [
+                    1014.1,
+                    1018.8
+                ],
+                "air_temperature": [
+                    20.2,
+                    28.6
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    25.4,
+                    73.7
+                ],
+                "uv_index": [
+                    2.8,
+                    9.4
+                ],
+                "wind_speed": [
+                    2.5,
+                    3.5
+                ]
+            },
+            "12": {
+                "air_pressure": [
+                    1013.0,
+                    1015.4
+                ],
+                "air_temperature": [
+                    25.6,
+                    29.1
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    20.6,
+                    22.7
+                ],
+                "uv_index": [
+                    0.0,
+                    4.5
+                ],
+                "wind_speed": [
+                    2.4,
+                    3.6
+                ]
+            },
+            "18": {
+                "air_pressure": [
+                    1016.2,
+                    1017.0
+                ],
+                "air_temperature": [
+                    19.3,
+                    24.6
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    25.6,
+                    85.9
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.1,
+                    6.0
+                ]
+            }
+        },
+        "2022-11-07": {
+            "0": {
+                "air_pressure": [
+                    1016.5,
+                    1018.5
+                ],
+                "air_temperature": [
+                    17.4,
+                    18.6
+                ],
+                "cloudiness": [
+                    0.0,
+                    100.0
+                ],
+                "fogginess": [
+                    0.0,
+                    100.0
+                ],
+                "relative_humidity": [
+                    92.1,
+                    99.3
+                ],
+                "uv_index": [
+                    0.0,
+                    0.8
+                ],
+                "wind_speed": [
+                    3.7,
+                    4.8
+                ]
+            },
+            "6": {
+                "air_pressure": [
+                    1013.5,
+                    1019.1
+                ],
+                "air_temperature": [
+                    19.6,
+                    28.3
+                ],
+                "cloudiness": [
+                    0.0,
+                    22.7
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    30.1,
+                    89.2
+                ],
+                "uv_index": [
+                    2.6,
+                    8.9
+                ],
+                "wind_speed": [
+                    3.3,
+                    4.3
+                ]
+            },
+            "12": {
+                "air_pressure": [
+                    1012.2,
+                    1012.6
+                ],
+                "air_temperature": [
+                    28.7,
+                    28.8
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    25.7,
+                    27.5
+                ],
+                "uv_index": [
+                    1.9,
+                    4.2
+                ],
+                "wind_speed": [
+                    2.9,
+                    3.0
+                ]
+            },
+            "18": {
+                "air_pressure": [
+                    1015.6,
+                    1015.6
+                ],
+                "air_temperature": [
+                    23.6,
+                    23.6
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    34.9,
+                    34.9
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.1,
+                    4.1
+                ]
+            }
+        },
+        "2022-11-08": {
+            "0": {
+                "air_pressure": [
+                    1015.5,
+                    1015.5
+                ],
+                "air_temperature": [
+                    17.9,
+                    17.9
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    73.7,
+                    73.7
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.6,
+                    4.6
+                ]
+            },
+            "6": {
+                "air_pressure": [
+                    1017.8,
+                    1017.8
+                ],
+                "air_temperature": [
+                    23.1,
+                    23.1
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    43.0,
+                    43.0
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    5.5,
+                    5.5
+                ]
+            },
+            "12": {
+                "air_pressure": [
+                    1012.0,
+                    1012.0
+                ],
+                "air_temperature": [
+                    29.0,
+                    29.0
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    20.1,
+                    20.1
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    3.6,
+                    3.6
+                ]
+            },
+            "18": {
+                "air_pressure": [
+                    1015.1,
+                    1015.1
+                ],
+                "air_temperature": [
+                    22.9,
+                    22.9
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    31.1,
+                    31.1
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    5.1,
+                    5.1
+                ]
+            }
+        },
+        "2022-11-09": {
+            "0": {
+                "air_pressure": [
+                    1014.9,
+                    1014.9
+                ],
+                "air_temperature": [
+                    17.1,
+                    17.1
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    76.9,
+                    76.9
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    5.1,
+                    5.1
+                ]
+            },
+            "6": {
+                "air_pressure": [
+                    1017.8,
+                    1017.8
+                ],
+                "air_temperature": [
+                    21.9,
+                    21.9
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    54.0,
+                    54.0
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    5.8,
+                    5.8
+                ]
+            },
+            "12": {
+                "air_pressure": [
+                    1012.5,
+                    1012.5
+                ],
+                "air_temperature": [
+                    28.9,
+                    28.9
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    19.0,
+                    19.0
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    3.2,
+                    3.2
+                ]
+            },
+            "18": {
+                "air_pressure": [
+                    1015.8,
+                    1015.8
+                ],
+                "air_temperature": [
+                    22.2,
+                    22.2
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    28.2,
+                    28.2
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.0,
+                    4.0
+                ]
+            }
+        },
+        "2022-11-10": {
+            "0": {
+                "air_pressure": [
+                    1015.9,
+                    1015.9
+                ],
+                "air_temperature": [
+                    16.4,
+                    16.4
+                ],
+                "cloudiness": [
+                    30.5,
+                    30.5
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    97.1,
+                    97.1
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.9,
+                    4.9
+                ]
+            },
+            "6": {
+                "air_pressure": [
+                    1018.7,
+                    1018.7
+                ],
+                "air_temperature": [
+                    20.5,
+                    20.5
+                ],
+                "cloudiness": [
+                    0.8,
+                    0.8
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    62.6,
+                    62.6
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    5.3,
+                    5.3
+                ]
+            },
+            "12": {
+                "air_pressure": [
+                    1014.0,
+                    1014.0
+                ],
+                "air_temperature": [
+                    28.0,
+                    28.0
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    18.7,
+                    18.7
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    5.2,
+                    5.2
+                ]
+            },
+            "18": {
+                "air_pressure": [
+                    1018.6,
+                    1018.6
+                ],
+                "air_temperature": [
+                    20.8,
+                    20.8
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    42.1,
+                    42.1
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.9,
+                    4.9
+                ]
+            }
+        },
+        "2022-11-11": {
+            "0": {
+                "air_pressure": [
+                    1017.8,
+                    1017.8
+                ],
+                "air_temperature": [
+                    15.5,
+                    15.5
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    71.3,
+                    71.3
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.1,
+                    4.1
+                ]
+            },
+            "6": {
+                "air_pressure": [
+                    1020.2,
+                    1020.2
+                ],
+                "air_temperature": [
+                    22.6,
+                    22.6
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    39.0,
+                    39.0
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    6.2,
+                    6.2
+                ]
+            },
+            "12": {
+                "air_pressure": [
+                    1014.4,
+                    1014.4
+                ],
+                "air_temperature": [
+                    28.1,
+                    28.1
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    18.6,
+                    18.6
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    6.4,
+                    6.4
+                ]
+            },
+            "18": {
+                "air_pressure": [
+                    1017.4,
+                    1017.4
+                ],
+                "air_temperature": [
+                    21.5,
+                    21.5
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    37.0,
+                    37.0
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    3.7,
+                    3.7
+                ]
+            }
+        },
+        "2022-11-12": {
+            "0": {
+                "air_pressure": [
+                    1016.9,
+                    1016.9
+                ],
+                "air_temperature": [
+                    16.1,
+                    16.1
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    88.7,
+                    88.7
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    3.3,
+                    3.3
+                ]
+            },
+            "6": {
+                "air_pressure": [
+                    1019.1,
+                    1019.1
+                ],
+                "air_temperature": [
+                    22.0,
+                    22.0
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    56.1,
+                    56.1
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.3,
+                    4.3
+                ]
+            },
+            "12": {
+                "air_pressure": [
+                    1013.7,
+                    1013.7
+                ],
+                "air_temperature": [
+                    27.0,
+                    27.0
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    20.4,
+                    20.4
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    5.1,
+                    5.1
+                ]
+            },
+            "18": {
+                "air_pressure": [
+                    1017.7,
+                    1017.7
+                ],
+                "air_temperature": [
+                    20.4,
+                    20.4
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    41.6,
+                    41.6
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.6,
+                    4.6
+                ]
+            }
+        },
+        "2022-11-13": {
+            "0": {
+                "air_pressure": [
+                    1016.4,
+                    1016.4
+                ],
+                "air_temperature": [
+                    15.7,
+                    15.7
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    66.0,
+                    66.0
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.4,
+                    4.4
+                ]
+            },
+            "6": {
+                "air_pressure": [
+                    1018.9,
+                    1018.9
+                ],
+                "air_temperature": [
+                    21.8,
+                    21.8
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    33.9,
+                    33.9
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.6,
+                    4.6
+                ]
+            },
+            "12": {
+                "air_pressure": [
+                    1013.2,
+                    1013.2
+                ],
+                "air_temperature": [
+                    27.1,
+                    27.1
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    15.8,
+                    15.8
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.3,
+                    4.3
+                ]
+            },
+            "18": {
+                "air_pressure": [
+                    1016.3,
+                    1016.3
+                ],
+                "air_temperature": [
+                    20.5,
+                    20.5
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    25.8,
+                    25.8
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.2,
+                    4.2
+                ]
+            }
+        },
+        "2022-11-14": {
+            "0": {
+                "air_pressure": [
+                    1016.0,
+                    1016.0
+                ],
+                "air_temperature": [
+                    15.3,
+                    15.3
+                ],
+                "cloudiness": [
+                    0.0,
+                    0.0
+                ],
+                "fogginess": [
+                    0.0,
+                    0.0
+                ],
+                "relative_humidity": [
+                    61.2,
+                    61.2
+                ],
+                "uv_index": [
+                    0.0,
+                    0.0
+                ],
+                "wind_speed": [
+                    4.1,
+                    4.1
+                ]
+            }
+        }
+    }
+}

--- a/_test/weather-0.json
+++ b/_test/weather-0.json
@@ -1,0 +1,3695 @@
+{
+    "type": "Feature",
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            49.19,
+            16.61,
+            1006
+        ]
+    },
+    "properties": {
+        "meta": {
+            "updated_at": "2022-11-04T19:26:30Z",
+            "units": {
+                "air_pressure_at_sea_level": "hPa",
+                "air_temperature": "celsius",
+                "air_temperature_max": "celsius",
+                "air_temperature_min": "celsius",
+                "cloud_area_fraction": "%",
+                "cloud_area_fraction_high": "%",
+                "cloud_area_fraction_low": "%",
+                "cloud_area_fraction_medium": "%",
+                "dew_point_temperature": "celsius",
+                "fog_area_fraction": "%",
+                "precipitation_amount": "mm",
+                "relative_humidity": "%",
+                "ultraviolet_index_clear_sky": "1",
+                "wind_from_direction": "degrees",
+                "wind_speed": "m/s"
+            }
+        },
+        "timeseries": [
+            {
+                "time": "2022-11-04T19:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.2,
+                            "air_temperature": 21.7,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 10.1,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 47.2,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 106.8,
+                            "wind_speed": 2.8
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 20.8,
+                            "air_temperature_min": 16.1,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-04T20:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.4,
+                            "air_temperature": 20.8,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 11.1,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 54.1,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 120.0,
+                            "wind_speed": 3.2
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 19.5,
+                            "air_temperature_min": 15.7,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-04T21:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.5,
+                            "air_temperature": 19.5,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 12.7,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 65.0,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 132.9,
+                            "wind_speed": 3.7
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 18.4,
+                            "air_temperature_min": 15.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-04T22:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.3,
+                            "air_temperature": 18.4,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 14.6,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 78.1,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 135.0,
+                            "wind_speed": 3.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 17.4,
+                            "air_temperature_min": 15.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-04T23:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.0,
+                            "air_temperature": 17.4,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.5,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 88.0,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 135.5,
+                            "wind_speed": 2.9
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 19.6,
+                            "air_temperature_min": 15.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T00:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.0,
+                            "air_temperature": 16.7,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.5,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 91.8,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 139.2,
+                            "wind_speed": 2.8
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 22.2,
+                            "air_temperature_min": 15.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T01:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.4,
+                            "air_temperature": 16.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.3,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 94.4,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 142.0,
+                            "wind_speed": 2.6
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 24.5,
+                            "air_temperature_min": 15.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T02:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.0,
+                            "air_temperature": 15.7,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.1,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 96.2,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 144.7,
+                            "wind_speed": 2.8
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 26.1,
+                            "air_temperature_min": 15.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T03:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.7,
+                            "air_temperature": 15.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.2,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 97.6,
+                            "ultraviolet_index_clear_sky": 0.1,
+                            "wind_from_direction": 147.6,
+                            "wind_speed": 3.0
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 27.3,
+                            "air_temperature_min": 17.3,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T04:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.6,
+                            "air_temperature": 17.3,
+                            "cloud_area_fraction": 10.9,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 10.9,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 16.5,
+                            "fog_area_fraction": 0.8,
+                            "relative_humidity": 94.7,
+                            "ultraviolet_index_clear_sky": 0.9,
+                            "wind_from_direction": 147.8,
+                            "wind_speed": 3.1
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.6,
+                            "air_temperature_min": 19.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T05:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1018.0,
+                            "air_temperature": 19.6,
+                            "cloud_area_fraction": 5.5,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 5.5,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 16.7,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 84.0,
+                            "ultraviolet_index_clear_sky": 2.9,
+                            "wind_from_direction": 147.3,
+                            "wind_speed": 2.9
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.6,
+                            "air_temperature_min": 22.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T06:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1018.2,
+                            "air_temperature": 22.2,
+                            "cloud_area_fraction": 0.8,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.8,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.6,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 65.8,
+                            "ultraviolet_index_clear_sky": 5.7,
+                            "wind_from_direction": 143.6,
+                            "wind_speed": 3.2
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.6,
+                            "air_temperature_min": 24.5,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T07:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.6,
+                            "air_temperature": 24.5,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 13.8,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 51.5,
+                            "ultraviolet_index_clear_sky": 8.3,
+                            "wind_from_direction": 132.6,
+                            "wind_speed": 3.1
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.6,
+                            "air_temperature_min": 26.1,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T08:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.4,
+                            "air_temperature": 26.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 11.8,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 41.3,
+                            "ultraviolet_index_clear_sky": 9.6,
+                            "wind_from_direction": 109.9,
+                            "wind_speed": 2.7
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.6,
+                            "air_temperature_min": 27.3,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T09:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.2,
+                            "air_temperature": 27.3,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 10.6,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 35.0,
+                            "ultraviolet_index_clear_sky": 9.2,
+                            "wind_from_direction": 82.7,
+                            "wind_speed": 2.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.6,
+                            "air_temperature_min": 26.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T10:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1014.0,
+                            "air_temperature": 28.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 8.1,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 27.7,
+                            "ultraviolet_index_clear_sky": 7.2,
+                            "wind_from_direction": 63.1,
+                            "wind_speed": 2.5
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.6,
+                            "air_temperature_min": 25.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T11:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1013.1,
+                            "air_temperature": 29.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 4.9,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 20.8,
+                            "ultraviolet_index_clear_sky": 4.4,
+                            "wind_from_direction": 53.5,
+                            "wind_speed": 3.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.6,
+                            "air_temperature_min": 24.0,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T12:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1012.8,
+                            "air_temperature": 29.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 3.6,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 19.2,
+                            "ultraviolet_index_clear_sky": 1.9,
+                            "wind_from_direction": 45.7,
+                            "wind_speed": 4.2
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.1,
+                            "air_temperature_min": 22.9,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T13:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1013.2,
+                            "air_temperature": 29.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 3.0,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 19.1,
+                            "ultraviolet_index_clear_sky": 0.5,
+                            "wind_from_direction": 42.6,
+                            "wind_speed": 4.7
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 27.8,
+                            "air_temperature_min": 22.0,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T14:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1013.6,
+                            "air_temperature": 27.8,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 3.6,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 21.1,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 43.2,
+                            "wind_speed": 4.5
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 26.6,
+                            "air_temperature_min": 21.3,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T15:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1014.2,
+                            "air_temperature": 26.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 4.6,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 24.2,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 37.4,
+                            "wind_speed": 4.1
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 25.4,
+                            "air_temperature_min": 20.1,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T16:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.0,
+                            "air_temperature": 25.4,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 5.4,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 27.8,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 47.1,
+                            "wind_speed": 3.7
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 24.0,
+                            "air_temperature_min": 19.1,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T17:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.0,
+                            "air_temperature": 24.0,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 5.9,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 31.0,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 61.8,
+                            "wind_speed": 2.8
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 22.9,
+                            "air_temperature_min": 18.1,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T18:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.7,
+                            "air_temperature": 22.9,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 6.8,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 35.5,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 93.4,
+                            "wind_speed": 3.0
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 22.0,
+                            "air_temperature_min": 17.3,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T19:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.8,
+                            "air_temperature": 22.0,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 9.4,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 44.4,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 89.7,
+                            "wind_speed": 3.0
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 21.3,
+                            "air_temperature_min": 16.7,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T20:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.9,
+                            "air_temperature": 21.3,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 10.5,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 50.0,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 114.4,
+                            "wind_speed": 3.6
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 20.1,
+                            "air_temperature_min": 16.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T21:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.3,
+                            "air_temperature": 20.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 9.7,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 51.5,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 128.0,
+                            "wind_speed": 3.6
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 19.1,
+                            "air_temperature_min": 16.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T22:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.1,
+                            "air_temperature": 19.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 11.8,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 63.0,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 138.5,
+                            "wind_speed": 3.7
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 18.1,
+                            "air_temperature_min": 16.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-05T23:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.8,
+                            "air_temperature": 18.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 14.0,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 76.4,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 138.6,
+                            "wind_speed": 3.8
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 20.2,
+                            "air_temperature_min": 16.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T00:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.7,
+                            "air_temperature": 17.3,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 14.9,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 84.9,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 142.2,
+                            "wind_speed": 3.7
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 22.9,
+                            "air_temperature_min": 16.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T01:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.9,
+                            "air_temperature": 16.7,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.4,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 91.5,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 142.8,
+                            "wind_speed": 3.6
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 25.2,
+                            "air_temperature_min": 16.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T02:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.1,
+                            "air_temperature": 16.4,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.5,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 93.8,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 145.7,
+                            "wind_speed": 3.4
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 26.6,
+                            "air_temperature_min": 16.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T03:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.8,
+                            "air_temperature": 16.2,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.3,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 94.3,
+                            "ultraviolet_index_clear_sky": 0.1,
+                            "wind_from_direction": 145.4,
+                            "wind_speed": 3.2
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 27.7,
+                            "air_temperature_min": 17.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T04:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1018.4,
+                            "air_temperature": 17.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.8,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 88.7,
+                            "ultraviolet_index_clear_sky": 0.9,
+                            "wind_from_direction": 148.2,
+                            "wind_speed": 2.9
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.6,
+                            "air_temperature_min": 20.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T05:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1018.8,
+                            "air_temperature": 20.2,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.3,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 73.7,
+                            "ultraviolet_index_clear_sky": 2.8,
+                            "wind_from_direction": 149.1,
+                            "wind_speed": 3.4
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.1,
+                            "air_temperature_min": 22.9,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T06:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1018.6,
+                            "air_temperature": 22.9,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 13.5,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 55.4,
+                            "ultraviolet_index_clear_sky": 5.5,
+                            "wind_from_direction": 148.5,
+                            "wind_speed": 3.5
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.1,
+                            "air_temperature_min": 25.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T07:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.9,
+                            "air_temperature": 25.2,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 11.6,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 42.9,
+                            "ultraviolet_index_clear_sky": 8.0,
+                            "wind_from_direction": 139.4,
+                            "wind_speed": 3.4
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.1,
+                            "air_temperature_min": 26.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T08:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.6,
+                            "air_temperature": 26.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 10.2,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 35.5,
+                            "ultraviolet_index_clear_sky": 9.4,
+                            "wind_from_direction": 120.9,
+                            "wind_speed": 2.8
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.1,
+                            "air_temperature_min": 27.7,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T09:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.2,
+                            "air_temperature": 27.7,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 8.6,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 30.0,
+                            "ultraviolet_index_clear_sky": 9.1,
+                            "wind_from_direction": 114.1,
+                            "wind_speed": 2.5
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.1,
+                            "air_temperature_min": 26.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T10:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1014.1,
+                            "air_temperature": 28.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 6.8,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 25.4,
+                            "ultraviolet_index_clear_sky": 7.2,
+                            "wind_from_direction": 118.1,
+                            "wind_speed": 2.8
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.1,
+                            "air_temperature_min": 25.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T11:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1013.2,
+                            "air_temperature": 29.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 5.6,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 22.7,
+                            "ultraviolet_index_clear_sky": 4.5,
+                            "wind_from_direction": 114.5,
+                            "wind_speed": 2.7
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.1,
+                            "air_temperature_min": 24.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T12:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1013.0,
+                            "air_temperature": 29.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 4.7,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 21.1,
+                            "ultraviolet_index_clear_sky": 2.0,
+                            "wind_from_direction": 106.9,
+                            "wind_speed": 2.5
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.9,
+                            "air_temperature_min": 23.5,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T13:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1013.2,
+                            "air_temperature": 28.9,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 4.1,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 20.6,
+                            "ultraviolet_index_clear_sky": 0.5,
+                            "wind_from_direction": 103.6,
+                            "wind_speed": 2.4
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.1,
+                            "air_temperature_min": 22.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T14:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1013.7,
+                            "air_temperature": 28.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 4.0,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 21.3,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 115.6,
+                            "wind_speed": 2.6
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 26.6,
+                            "air_temperature_min": 21.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T15:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1014.6,
+                            "air_temperature": 26.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 3.3,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 22.2,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 129.6,
+                            "wind_speed": 3.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 25.6,
+                            "air_temperature_min": 20.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T16:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.4,
+                            "air_temperature": 25.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 2.2,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 22.2,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 136.3,
+                            "wind_speed": 3.6
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "fair_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 24.6,
+                            "air_temperature_min": 19.3,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T17:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.2,
+                            "air_temperature": 24.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 3.5,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 25.6,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 138.7,
+                            "wind_speed": 4.1
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "fair_night"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 23.5,
+                            "air_temperature_min": 18.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T18:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.7,
+                            "air_temperature": 23.5,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 4.7,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 29.3,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 120.9,
+                            "wind_speed": 4.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 22.4,
+                            "air_temperature_min": 18.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T19:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.9,
+                            "air_temperature": 22.4,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 7.3,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 37.9,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 118.1,
+                            "wind_speed": 5.0
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 21.2,
+                            "air_temperature_min": 17.8,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T20:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.0,
+                            "air_temperature": 21.2,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 13.7,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 62.4,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 123.5,
+                            "wind_speed": 6.0
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 20.2,
+                            "air_temperature_min": 17.5,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T21:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.8,
+                            "air_temperature": 20.2,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.9,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 76.6,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 134.0,
+                            "wind_speed": 5.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "fair_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 19.3,
+                            "air_temperature_min": 17.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T22:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.7,
+                            "air_temperature": 19.3,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 16.8,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 85.9,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 142.4,
+                            "wind_speed": 5.0
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "partlycloudy_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 18.6,
+                            "air_temperature_min": 17.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-06T23:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.5,
+                            "air_temperature": 18.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 17.3,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 92.1,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 139.0,
+                            "wind_speed": 4.8
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "partlycloudy_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 19.6,
+                            "air_temperature_min": 17.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T00:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.6,
+                            "air_temperature": 18.2,
+                            "cloud_area_fraction": 0.8,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.8,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 17.3,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 94.6,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 137.7,
+                            "wind_speed": 4.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "partlycloudy_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 22.3,
+                            "air_temperature_min": 17.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T01:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.9,
+                            "air_temperature": 17.8,
+                            "cloud_area_fraction": 0.8,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.8,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 17.3,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 97.0,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 134.7,
+                            "wind_speed": 4.1
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "partlycloudy_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 24.6,
+                            "air_temperature_min": 17.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T02:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.2,
+                            "air_temperature": 17.5,
+                            "cloud_area_fraction": 43.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 43.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 17.3,
+                            "fog_area_fraction": 21.9,
+                            "relative_humidity": 98.8,
+                            "ultraviolet_index_clear_sky": 0.0,
+                            "wind_from_direction": 134.4,
+                            "wind_speed": 4.0
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "partlycloudy_night"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 26.5,
+                            "air_temperature_min": 17.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T03:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.9,
+                            "air_temperature": 17.4,
+                            "cloud_area_fraction": 99.2,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 99.2,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 17.2,
+                            "fog_area_fraction": 94.5,
+                            "relative_humidity": 99.3,
+                            "ultraviolet_index_clear_sky": 0.1,
+                            "wind_from_direction": 137.1,
+                            "wind_speed": 3.7
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "fog"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 27.6,
+                            "air_temperature_min": 18.0,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T04:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1018.5,
+                            "air_temperature": 18.0,
+                            "cloud_area_fraction": 100.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 100.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 17.7,
+                            "fog_area_fraction": 100.0,
+                            "relative_humidity": 98.1,
+                            "ultraviolet_index_clear_sky": 0.8,
+                            "wind_from_direction": 138.6,
+                            "wind_speed": 3.8
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "fog"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.3,
+                            "air_temperature_min": 19.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T05:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1019.1,
+                            "air_temperature": 19.6,
+                            "cloud_area_fraction": 22.7,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 22.7,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 17.7,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 89.2,
+                            "ultraviolet_index_clear_sky": 2.6,
+                            "wind_from_direction": 146.6,
+                            "wind_speed": 3.9
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.7,
+                            "air_temperature_min": 22.3,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T06:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1018.8,
+                            "air_temperature": 22.3,
+                            "cloud_area_fraction": 3.9,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 3.9,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 16.7,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 70.6,
+                            "ultraviolet_index_clear_sky": 5.2,
+                            "wind_from_direction": 153.0,
+                            "wind_speed": 4.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.8,
+                            "air_temperature_min": 24.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T07:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.8,
+                            "air_temperature": 24.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.2,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 55.9,
+                            "ultraviolet_index_clear_sky": 7.6,
+                            "wind_from_direction": 153.9,
+                            "wind_speed": 4.3
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T08:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.3,
+                            "air_temperature": 26.5,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 12.1,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 40.8,
+                            "ultraviolet_index_clear_sky": 8.9,
+                            "wind_from_direction": 148.9,
+                            "wind_speed": 4.2
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T09:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1014.7,
+                            "air_temperature": 27.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 10.3,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 33.6,
+                            "ultraviolet_index_clear_sky": 8.6,
+                            "wind_from_direction": 142.3,
+                            "wind_speed": 3.8
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T10:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1013.5,
+                            "air_temperature": 28.3,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 9.1,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 30.1,
+                            "ultraviolet_index_clear_sky": 6.8,
+                            "wind_from_direction": 131.9,
+                            "wind_speed": 3.3
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T11:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1012.6,
+                            "air_temperature": 28.7,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 8.1,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 27.5,
+                            "ultraviolet_index_clear_sky": 4.2,
+                            "wind_from_direction": 117.7,
+                            "wind_speed": 3.0
+                        }
+                    },
+                    "next_1_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T12:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1012.2,
+                            "air_temperature": 28.8,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 7.2,
+                            "fog_area_fraction": 0.0,
+                            "relative_humidity": 25.7,
+                            "ultraviolet_index_clear_sky": 1.9,
+                            "wind_from_direction": 105.7,
+                            "wind_speed": 2.9
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.8,
+                            "air_temperature_min": 23.7,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-07T18:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.6,
+                            "air_temperature": 23.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 7.2,
+                            "relative_humidity": 34.9,
+                            "wind_from_direction": 129.6,
+                            "wind_speed": 4.1
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 23.6,
+                            "air_temperature_min": 18.0,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-08T00:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.5,
+                            "air_temperature": 17.9,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 13.2,
+                            "relative_humidity": 73.7,
+                            "wind_from_direction": 142.8,
+                            "wind_speed": 4.6
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 22.8,
+                            "air_temperature_min": 16.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-08T06:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.8,
+                            "air_temperature": 23.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 10.0,
+                            "relative_humidity": 43.0,
+                            "wind_from_direction": 143.1,
+                            "wind_speed": 5.5
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.0,
+                            "air_temperature_min": 23.1,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-08T12:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1012.0,
+                            "air_temperature": 29.0,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 3.9,
+                            "relative_humidity": 20.1,
+                            "wind_from_direction": 134.8,
+                            "wind_speed": 3.6
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 29.0,
+                            "air_temperature_min": 23.0,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-08T18:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.1,
+                            "air_temperature": 22.9,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 5.1,
+                            "relative_humidity": 31.1,
+                            "wind_from_direction": 118.9,
+                            "wind_speed": 5.1
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 22.9,
+                            "air_temperature_min": 17.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-09T00:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1014.9,
+                            "air_temperature": 17.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 13.1,
+                            "relative_humidity": 76.9,
+                            "wind_from_direction": 148.6,
+                            "wind_speed": 5.1
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 21.6,
+                            "air_temperature_min": 15.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-09T06:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.8,
+                            "air_temperature": 21.9,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 12.1,
+                            "relative_humidity": 54.0,
+                            "wind_from_direction": 140.9,
+                            "wind_speed": 5.8
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.9,
+                            "air_temperature_min": 21.9,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-09T12:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1012.5,
+                            "air_temperature": 28.9,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 2.9,
+                            "relative_humidity": 19.0,
+                            "wind_from_direction": 110.6,
+                            "wind_speed": 3.2
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.9,
+                            "air_temperature_min": 22.3,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-09T18:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.8,
+                            "air_temperature": 22.2,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 2.9,
+                            "relative_humidity": 28.2,
+                            "wind_from_direction": 103.6,
+                            "wind_speed": 4.0
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 22.1,
+                            "air_temperature_min": 16.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-10T00:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1015.9,
+                            "air_temperature": 16.4,
+                            "cloud_area_fraction": 30.5,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 30.5,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 15.9,
+                            "relative_humidity": 97.1,
+                            "wind_from_direction": 138.6,
+                            "wind_speed": 4.9
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "fair_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 20.1,
+                            "air_temperature_min": 15.9,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-10T06:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1018.7,
+                            "air_temperature": 20.5,
+                            "cloud_area_fraction": 0.8,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.8,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 13.0,
+                            "relative_humidity": 62.6,
+                            "wind_from_direction": 140.9,
+                            "wind_speed": 5.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.1,
+                            "air_temperature_min": 20.5,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-10T12:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1014.0,
+                            "air_temperature": 28.0,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 2.0,
+                            "relative_humidity": 18.7,
+                            "wind_from_direction": 106.0,
+                            "wind_speed": 5.2
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.0,
+                            "air_temperature_min": 20.8,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-10T18:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1018.6,
+                            "air_temperature": 20.8,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 7.3,
+                            "relative_humidity": 42.1,
+                            "wind_from_direction": 98.3,
+                            "wind_speed": 4.9
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 20.7,
+                            "air_temperature_min": 15.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-11T00:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.8,
+                            "air_temperature": 15.5,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 10.4,
+                            "relative_humidity": 71.3,
+                            "wind_from_direction": 124.0,
+                            "wind_speed": 4.1
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 22.4,
+                            "air_temperature_min": 14.9,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-11T06:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1020.2,
+                            "air_temperature": 22.6,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 7.9,
+                            "relative_humidity": 39.0,
+                            "wind_from_direction": 119.5,
+                            "wind_speed": 6.2
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.2,
+                            "air_temperature_min": 22.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-11T12:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1014.4,
+                            "air_temperature": 28.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 1.9,
+                            "relative_humidity": 18.6,
+                            "wind_from_direction": 102.8,
+                            "wind_speed": 6.4
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 28.1,
+                            "air_temperature_min": 21.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-11T18:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.4,
+                            "air_temperature": 21.5,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 6.2,
+                            "relative_humidity": 37.0,
+                            "wind_from_direction": 120.8,
+                            "wind_speed": 3.7
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 21.5,
+                            "air_temperature_min": 16.2,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-12T00:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.9,
+                            "air_temperature": 16.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 14.3,
+                            "relative_humidity": 88.7,
+                            "wind_from_direction": 112.8,
+                            "wind_speed": 3.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 21.7,
+                            "air_temperature_min": 14.9,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-12T06:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1019.1,
+                            "air_temperature": 22.0,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 12.8,
+                            "relative_humidity": 56.1,
+                            "wind_from_direction": 110.9,
+                            "wind_speed": 4.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 27.1,
+                            "air_temperature_min": 22.0,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-12T12:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1013.7,
+                            "air_temperature": 27.0,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 2.4,
+                            "relative_humidity": 20.4,
+                            "wind_from_direction": 106.9,
+                            "wind_speed": 5.1
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 27.0,
+                            "air_temperature_min": 20.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-12T18:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1017.7,
+                            "air_temperature": 20.4,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 6.8,
+                            "relative_humidity": 41.6,
+                            "wind_from_direction": 98.5,
+                            "wind_speed": 4.6
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 20.4,
+                            "air_temperature_min": 15.8,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-13T00:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.4,
+                            "air_temperature": 15.7,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 9.4,
+                            "relative_humidity": 66.0,
+                            "wind_from_direction": 137.0,
+                            "wind_speed": 4.4
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 21.5,
+                            "air_temperature_min": 14.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-13T06:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1018.9,
+                            "air_temperature": 21.8,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 5.3,
+                            "relative_humidity": 33.9,
+                            "wind_from_direction": 137.1,
+                            "wind_speed": 4.6
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_day"
+                        },
+                        "details": {
+                            "air_temperature_max": 27.1,
+                            "air_temperature_min": 21.8,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-13T12:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1013.2,
+                            "air_temperature": 27.1,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": -1.0,
+                            "relative_humidity": 15.8,
+                            "wind_from_direction": 114.1,
+                            "wind_speed": 4.3
+                        }
+                    },
+                    "next_12_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 27.1,
+                            "air_temperature_min": 20.6,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-13T18:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.3,
+                            "air_temperature": 20.5,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 0.2,
+                            "relative_humidity": 25.8,
+                            "wind_from_direction": 99.1,
+                            "wind_speed": 4.2
+                        }
+                    },
+                    "next_6_hours": {
+                        "summary": {
+                            "symbol_code": "clearsky_night"
+                        },
+                        "details": {
+                            "air_temperature_max": 20.5,
+                            "air_temperature_min": 15.4,
+                            "precipitation_amount": 0.0
+                        }
+                    }
+                }
+            },
+            {
+                "time": "2022-11-14T00:00:00Z",
+                "data": {
+                    "instant": {
+                        "details": {
+                            "air_pressure_at_sea_level": 1016.0,
+                            "air_temperature": 15.3,
+                            "cloud_area_fraction": 0.0,
+                            "cloud_area_fraction_high": 0.0,
+                            "cloud_area_fraction_low": 0.0,
+                            "cloud_area_fraction_medium": 0.0,
+                            "dew_point_temperature": 7.8,
+                            "relative_humidity": 61.2,
+                            "wind_from_direction": 138.1,
+                            "wind_speed": 4.1
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/po/cs.popie
+++ b/po/cs.popie
@@ -340,14 +340,17 @@ msgstr Odpoledne
 msgid Evening
 msgstr Večer
 
+msgid Today
+msgstr Dnes
+
+msgid Tomorrow
+msgstr Zítra
+
 msgid Weather forecast for **{place}, {country}**
 msgstr Předpověď počasí pro **{place}, {country}**
 
 msgid Temperature: **{valmin} - {valmax} ˚C**
 msgstr Teplota: **{valmin} - {valmax} ˚C**
-
-msgid Air pressure: **{valmax} hPa**
-msgstr Tlak: **{valmax} hPa**
 
 msgid Clouds: **{valmax} %**
 msgstr Oblačnost: **{valmax} %**
@@ -355,11 +358,20 @@ msgstr Oblačnost: **{valmax} %**
 msgid Relative humidity: **{valmax} %**
 msgstr Relativní vlhkost: **{valmax} %**
 
-msgid Wind speed: **{valmax} m/s**
-msgstr Vítr: **{valmax} m/s**
-
 msgid Fogginess: **{valmax}**
 msgstr Mlha: **{valmax} %**
+
+msgid *Air pressure: {valmin} - {valmax} hPa*
+msgstr *Tlak: {valmin} - {valmax} hPa*
+
+msgid *Wind speed: up to {valmax} m/s*
+msgstr *Rychlost větru: až {valmax} m/s*
+
+msgid *UV index: up to {valmax}*
+msgstr *UV index: až {valmax}*
+
+msgid *Extra information*
+msgstr *Doplňující informace*
 
 msgid That's not valid place name.
 msgstr To není platný název místa.

--- a/po/cs.popie
+++ b/po/cs.popie
@@ -328,41 +328,38 @@ msgstr Všechny položky byly vymazány.
 msgid Ask me what you want to know and I will answer.
 msgstr Zeptej se mě na to, co chceš vědět a já ti odpovím.
 
-msgid Morning
-msgstr Ráno
-
-msgid Day
-msgstr Dopoledne
-
-msgid Evening
-msgstr Odpoledne
-
 msgid Night
 msgstr Noc
 
-msgid An error occured while getting weather info.
-msgstr Při získávání informací o počasí došlo k chybě.
+msgid Morning
+msgstr Ráno
 
-msgid Did not receive JSON response.
-msgstr Na výstupu jsme nedostali typ JSON.
+msgid Afternoon
+msgstr Odpoledne
 
-msgid Today
-msgstr Dnes
+msgid Evening
+msgstr Večer
 
-msgid Tomorrow
-msgstr Zítra
+msgid Weather forecast for **{place}, {country}**
+msgstr Předpověď počasí pro **{place}, {country}**
 
-msgid Weather forecast for **{place}**, {date}
-msgstr Předpověď počasí pro **{place}**, {date}
+msgid Temperature: **{valmin} - {valmax} ˚C**
+msgstr Teplota: **{valmin} - {valmax} ˚C**
 
-msgid Temperature: **{real} ˚C** (feels like **{feel} ˚C**)
-msgstr Teplota: **{real} ˚C** (pocitově **{feel} ˚C**)
+msgid Air pressure: **{valmax} hPa**
+msgstr Tlak: **{valmax} hPa**
 
-msgid Wind speed: **{wind} km/h**
-msgstr Rychlost větru: **{wind} km/h**
+msgid Clouds: **{valmax} %**
+msgstr Oblačnost: **{valmax} %**
 
-msgid Chance of rain: **{rain} %**
-msgstr Pravděpodobnost srážek: **{rain} %**
+msgid Relative humidity: **{valmax} %**
+msgstr Relativní vlhkost: **{valmax} %**
+
+msgid Wind speed: **{valmax} m/s**
+msgstr Vítr: **{valmax} m/s**
+
+msgid Fogginess: **{valmax}**
+msgstr Mlha: **{valmax} %**
 
 msgid That's not valid place name.
 msgstr To není platný název místa.

--- a/po/cs.popie
+++ b/po/cs.popie
@@ -409,6 +409,12 @@ msgstr Preference serveru
 msgid You have to specify a place or set a preference.
 msgstr Musíš uvést místo nebo si nastavit preferenci.
 
+msgid Submitted place could not be found.
+msgstr Zadané místo nebylo nalezeno.
+
+msgid Forecast server refused the geolocation.
+msgstr Server odmítl geografickou lokaci.
+
 msgid Characters
 msgstr Charaktery
 

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -328,41 +328,38 @@ msgstr Všetky položky boli odstránené.
 msgid Ask me what you want to know and I will answer.
 msgstr Opýtaj sa ma čo chceš vedieť a ja ti odpoviem.
 
+msgid Night
+msgstr Noc
+
 msgid Morning
 msgstr Ráno
 
-msgid Day
-msgstr Deň
+msgid Afternoon
+msgstr
 
 msgid Evening
 msgstr Večer
 
-msgid Night
-msgstr Noc
+msgid Weather forecast for **{place}, {country}**
+msgstr
 
-msgid An error occured while getting weather info.
-msgstr Pri získavaní počasia nastala chyba.
+msgid Temperature: **{valmin} - {valmax} ˚C**
+msgstr
 
-msgid Did not receive JSON response.
-msgstr Na výstupe sme nedostali typ JSON.
+msgid Air pressure: **{valmax} hPa**
+msgstr
 
-msgid Today
-msgstr Dnes
+msgid Clouds: **{valmax} %**
+msgstr
 
-msgid Tomorrow
-msgstr Zajtra
+msgid Relative humidity: **{valmax} %**
+msgstr
 
-msgid Weather forecast for **{place}**, {date}
-msgstr Predpoveď počasia pre **{place}**, {date}
+msgid Wind speed: **{valmax} m/s**
+msgstr
 
-msgid Temperature: **{real} ˚C** (feels like **{feel} ˚C**)
-msgstr Teplota: **{real} ˚C** (pocitovo **{feel} ˚C**)
-
-msgid Wind speed: **{wind} km/h**
-msgstr Rýchlosť vetra: **{wind} km/h**
-
-msgid Chance of rain: **{rain} %**
-msgstr Pravdepodobnosť dažďa: **{rain} %**
+msgid Fogginess: **{valmax}**
+msgstr
 
 msgid That's not valid place name.
 msgstr Tento názov miesta nieje platný.

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -340,13 +340,16 @@ msgstr
 msgid Evening
 msgstr Večer
 
+msgid Today
+msgstr
+
+msgid Tomorrow
+msgstr
+
 msgid Weather forecast for **{place}, {country}**
 msgstr
 
 msgid Temperature: **{valmin} - {valmax} ˚C**
-msgstr
-
-msgid Air pressure: **{valmax} hPa**
 msgstr
 
 msgid Clouds: **{valmax} %**
@@ -355,10 +358,19 @@ msgstr
 msgid Relative humidity: **{valmax} %**
 msgstr
 
-msgid Wind speed: **{valmax} m/s**
+msgid Fogginess: **{valmax}**
 msgstr
 
-msgid Fogginess: **{valmax}**
+msgid *Air pressure: {valmin} - {valmax} hPa*
+msgstr
+
+msgid *Wind speed: up to {valmax} m/s*
+msgstr
+
+msgid *UV index: up to {valmax}*
+msgstr
+
+msgid *Extra information*
 msgstr
 
 msgid That's not valid place name.

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -409,6 +409,12 @@ msgstr Preferencie servera
 msgid You have to specify a place or set a preference.
 msgstr Musíš zadať miesto alebo si nastaviť preferenciu.
 
+msgid Submitted place could not be found.
+msgstr
+
+msgid Forecast server refused the geolocation.
+msgstr
+
 msgid Characters
 msgstr Znaky
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,8 @@
 pre-commit
 
+# tests
+pytest
+
 # static analysis
 black==22.8.0
 flake8==5.0.4

--- a/weather/module.py
+++ b/weather/module.py
@@ -210,7 +210,7 @@ class Weather(commands.Cog):
     @commands.command(name="set-weather-place")
     async def set_weather_place(self, ctx, *, name: str):
         """Set preferred place for weather and forecast information."""
-        if not self._place_is_valid(name):
+        if not self._is_place_valid(name):
             await ctx.reply(_(ctx, "That's not valid place name."))
             return
         Place.set(ctx.guild.id, ctx.author.id, name)
@@ -239,7 +239,7 @@ class Weather(commands.Cog):
     @commands.command(name="set-guild-weather-place")
     async def set_guild_weather_place(self, ctx, *, name: str):
         """Set guild's preferred place for weather and forecast information."""
-        if not self._place_is_valid(name):
+        if not self._is_place_valid(name):
             await ctx.reply(_(ctx, "That's not valid place name."))
             return
         Place.set(ctx.guild.id, None, name)
@@ -297,29 +297,29 @@ class Weather(commands.Cog):
     @commands.guild_only()
     @check.acl2(check.ACLevel.MEMBER)
     @commands.command(name="weather")
-    async def weather(self, ctx, *, name: Optional[str] = None):
+    async def weather(self, ctx, *, place: Optional[str] = None):
         """Get weather information on any place."""
-        if name is None:
+        if place is None:
             # try to get user preference
-            place = Place.get(ctx.guild.id, ctx.author.id)
-            if place is not None:
-                name = place.name
-        if name is None:
+            place_pref = Place.get(ctx.guild.id, ctx.author.id)
+            if place_pref is not None:
+                place = place_pref.name
+        if place is None:
             # try to get guild preference
-            place = Place.get(ctx.guild.id, None)
-            if place is not None:
-                name = place.name
-        if name is None:
+            place_pref = Place.get(ctx.guild.id, None)
+            if place_pref is not None:
+                place = place_pref.name
+        if place is None:
             await ctx.reply(_(ctx, "You have to specify a place or set a preference."))
             return
 
         lang_preference = translator.get_language_preference(ctx)
         async with ctx.typing():
-            embeds = await self._create_embeds(ctx, name, lang_preference)
+            embeds = await self._create_embeds(ctx, place, lang_preference)
             scroll_embed = utils.ScrollableEmbed(ctx, embeds)
         await scroll_embed.scroll()
 
-    def _place_is_valid(self, name: str) -> bool:
+    def _is_place_valid(self, name: str) -> bool:
         for char in ("&", "#", "?"):
             if char in name:
                 return False

--- a/weather/process.py
+++ b/weather/process.py
@@ -1,0 +1,101 @@
+"""
+Filter function. Moved from the main module for testing reasons.
+
+The received met.no report contains daily report for at least next three days,
+then quarter-day report for next five days. That is too much.
+"""
+import datetime
+import dateutil.parser
+from collections import defaultdict
+from typing import List, Dict, Tuple
+
+
+def filter_forecast_data(
+    data: dict,
+    timezone: datetime.tzinfo = datetime.datetime.now().astimezone().tzinfo,
+) -> dict:
+    """Filter forecast data."""
+    result = {
+        "meta": data["properties"]["meta"],
+        "data": {},
+    }
+
+    days = split_into_days(data["properties"]["timeseries"], timezone=timezone)
+    for day, day_values in days.items():
+        day_points = {
+            time: filter_point(time_data) for time, time_data in day_values.items()
+        }
+        joined_day_points = join_points(day_points)
+        result["data"][day] = joined_day_points
+
+    return result
+
+
+def split_into_days(
+    points: List[dict],
+    timezone: datetime.tzinfo = datetime.datetime.now().astimezone().tzinfo,
+) -> dict:
+    """Split time series into individual days.
+
+    This also converts from UTC to local time.
+    """
+    result = defaultdict(lambda: {})
+    for point in points:
+        timestamp = dateutil.parser.parse(point["time"])
+        timestamp = timestamp.astimezone(timezone)
+        date = timestamp.strftime("%Y-%m-%d")
+        time = timestamp.strftime("%H:%M:%S")
+        result[date][time] = point["data"]
+    return dict(result)
+
+
+def filter_point(point: dict) -> dict:
+    """Filter unnecessary information from an entry."""
+    details = point["instant"]["details"]
+    result = {
+        "air_pressure": details["air_pressure_at_sea_level"],
+        "air_temperature": details["air_temperature"],
+        "cloudiness": details["cloud_area_fraction"],
+        "fogginess": details.get("fog_area_fraction", 0.0),
+        "relative_humidity": details["relative_humidity"],
+        "uv_index": details.get("ultraviolet_index_clear_sky", 0.0),
+        "wind_speed": details["wind_speed"],
+    }
+    return result
+
+
+def join_points(points: Dict[str, dict]) -> dict:
+    """Join time points into four day sections.
+
+    Returns minimal and maximal value for each of observed values
+    for each of time sections.
+    """
+    pre_result = defaultdict(lambda: defaultdict(lambda: set()))
+    for time, data in points.items():
+        hour = int(time.split(":", 1)[0])
+        round_hour = int(hour // 6) * 6
+
+        for kw, value in data.items():
+            pre_result[round_hour][kw].add(value)
+
+    result = defaultdict(lambda: defaultdict(lambda: {}))
+    for time, kw_values in pre_result.items():
+        for kw, values in kw_values.items():
+            values_min = min(values)
+            values_max = max(values)
+            result[time][kw] = (values_min, values_max)
+
+    return result
+
+
+def get_day_minmax(day: dict) -> Dict[str, Tuple[float, float]]:
+    result = {}
+    for _, data in day.items():
+        for kw, values in data.items():
+            if kw not in result:
+                result[kw] = values
+            else:
+                result[kw] = min(result[kw][0], values[0]), max(
+                    result[kw][1], values[1]
+                )
+    return result


### PR DESCRIPTION
Resolves #94 

The previous provider has been quite unreliable and vague. YR.no is much more detailed.

The current output does not contain rain probability or milimeters of rain, that could be done later.