### PR TITLE
Fix weeb command and fix some popie strings 

### DIFF
--- a/po/cs.popie
+++ b/po/cs.popie
@@ -20,7 +20,7 @@ msgid Channel {channel} added as hash channel with reaction limit **{reaction_li
 msgstr {channel} byl přidán jako hash kanál s limitem **{reaction_limit}** reakcí.
 
 msgid {channel} is not hash channel.
-msgstr {channel} není hash kanál
+msgstr {channel} není hash kanál.
 
 msgid Reaction limit must be higher than 0.
 msgstr Limit reakcí musí být vyšší než 0.
@@ -38,7 +38,7 @@ msgid **LOADING**
 msgstr **NAČÍTÁNÍ**
 
 msgid Downloaded **{count}** messages.
-msgstr Staženo **{count}** zpráv
+msgstr Staženo **{count}** zpráv.
 
 msgid **SCANNING**
 msgstr **SKENOVÁNÍ**
@@ -62,7 +62,7 @@ msgid Message **`{message_id}`**
 msgstr Zpráva **`{message_id}`**
 
 msgid Messages has no associtated hashes.
-msgstr Ke zprávám nepatří žádné hashe
+msgstr Ke zprávám nepatří žádné hashe.
 
 msgid **♻ This is repost!**
 msgstr **♻ Tohle je repost!**
@@ -206,7 +206,7 @@ msgid Macro **{name}** created.
 msgstr Makro **{name}** vytvořeno.
 
 msgid No arguments specified.
-msgstr Nebyly uvedeny žádné argument.y
+msgstr Nebyly uvedeny žádné argumenty.
 
 msgid Macro **{name}** updated.
 msgstr Makro **{name}** aktualizováno.
@@ -218,7 +218,7 @@ msgid Nickname change prices
 msgstr Ceny změn přezdívek
 
 msgid Values are in karma points.
-msgstr Hodnoty jsou v karma bodech
+msgstr Hodnoty jsou v karma bodech.
 
 msgid Set
 msgstr Změna
@@ -284,7 +284,7 @@ msgid Set nor reset price cannot be negative.
 msgstr Cena za nastavení ani zrušení nemůže být negativní.
 
 msgid Prices have been successfully updated.
-msgstr Ceny byly uspěšně aktualizovány.
+msgstr Ceny byly úspěšně aktualizovány.
 
 msgid Prices have not been successfully updated.
 msgstr Ceny nebyly úspěšně aktualizovány.
@@ -463,7 +463,7 @@ msgstr Kategorie
 msgid Number of pages
 msgstr Počet stran
 
-msgid Supply me with a magic number and I will give you what you desire
+msgid Supply me with a magic number and I will give you what you desire.
 msgstr Dodej mi kouzelné číslo a já ti dám, co si přeješ.
 
 msgid The request will fail because user-agent and cf_clearance cookie is not set.

--- a/po/cs.popie
+++ b/po/cs.popie
@@ -465,3 +465,12 @@ msgstr Počet stran
 
 msgid Supply me with a magic number and I will give you what you desire
 msgstr Dodej mi kouzelné číslo a já ti dám, co si přeješ.
+
+msgid The request will fail because user-agent and cf_clearance cookie is not set.
+msgstr Dotaz selže jelikož není nastavem user-agent a cf_clearance cookie.
+
+msgid Connection details have been successfully updated.
+msgstr Podrobnosti o spojení byly úspěšně aktualizovány.
+
+msgid Connection details have not been successfully updated.
+msgstr Podrobnosti o spojení nebyly úspěšně aktualizovány.

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -465,3 +465,12 @@ msgstr Počet strán
 
 msgid Supply me with a magic number and I will give you what you desire
 msgstr Dodaj mi kúzelné číslo a ja ti dám, čo si praješ.
+
+msgid The request will fail because user-agent and cf_clearance cookie is not set.
+msgstr
+
+msgid Connection details have been successfully updated.
+msgstr
+
+msgid Connection details have not been successfully updated.
+msgstr

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -463,7 +463,7 @@ msgstr Kategórie
 msgid Number of pages
 msgstr Počet strán
 
-msgid Supply me with a magic number and I will give you what you desire
+msgid Supply me with a magic number and I will give you what you desire.
 msgstr Dodaj mi kúzelné číslo a ja ti dám, čo si praješ.
 
 msgid The request will fail because user-agent and cf_clearance cookie is not set.

--- a/rand/module.py
+++ b/rand/module.py
@@ -239,9 +239,7 @@ class Rand(commands.Cog):
         """Get random image of a duck"""
         headers = self._get_request_headers()
         async with aiohttp.ClientSession(headers=headers) as session:
-            async with session.get(
-                "https://random-d.uk/api/v2/random"
-            ) as response:
+            async with session.get("https://random-d.uk/api/v2/random") as response:
                 if response.status != 200:
                     return await ctx.reply(
                         _(ctx, "Command encountered an error (E{code}).").format(

--- a/weeb/database.py
+++ b/weeb/database.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import Column, BigInteger, String
+
+from pie.database import database, session
+
+
+class Details(database.base):
+    """User-agent and cf_clearance cookie for weeb module"""
+
+    __tablename__ = "fun_weeb_connection_details"
+
+    guild_id = Column(BigInteger, primary_key=True)
+    user_agent = Column(String)
+    cf_clearance = Column(String)
+
+    @staticmethod
+    def set(guild_id: int, user_agent: str, cf_clearance: str) -> Details:
+        """Add or update connection values."""
+        details = Details.get(guild_id)
+        if details is not None:
+            details.user_agent = user_agent
+            details.cf_clearance = cf_clearance
+        else:
+            details = Details(
+                guild_id=guild_id,
+                user_agent=user_agent,
+                cf_clearance=cf_clearance,
+            )
+        session.add(details)
+        session.commit()
+        return details
+
+    @staticmethod
+    def get(guild_id: int) -> Optional[Details]:
+        """Get connection details in supplied guild."""
+        return session.query(Details).filter_by(guild_id=guild_id).one_or_none()
+
+    @staticmethod
+    def remove(guild_id: int) -> int:
+        """Remove connection details in supplied guild."""
+        details = session.query(Details).filter_by(guild_id=guild_id).delete()
+        session.commit()
+        return details

--- a/weeb/module.py
+++ b/weeb/module.py
@@ -93,7 +93,7 @@ class Weeb(commands.Cog):
                     ">>> "
                     + _(
                         ctx,
-                        "Supply me with a magic number and I will give you what you desire",
+                        "Supply me with a magic number and I will give you what you desire.",
                     )
                 )
                 return


### PR DESCRIPTION
Hi, this PR resolve #86 . The fix for this is add user-agent and  cf_clearance cookie. These two values must be from same session or at least from same browser, because of my testing when I just change user-agent the request not worked. So the cf_clearance cookie is somehow bound to user-agent. The cookie have expiration 1 year so user must update it so database table was added. 

When I run black the random module updated so I added it to standalone commit. If you want I drop it but don't know if github action tests pass.

In last commit I found some small fix in translation string so I fix them.