### PR TITLE
missing title

### DIFF
--- a/rand/module.py
+++ b/rand/module.py
@@ -355,6 +355,7 @@ class Rand(commands.Cog):
             result = fetched
 
         embed: discord.Embed = utils.discord.create_embed(
+            title="Dadjoke",
             author=ctx.author,
             description=result["joke"],
             footer="icanhazdadjoke.com",


### PR DESCRIPTION
When using url in embed we need title to be able to redirect else I would suggest removing url.